### PR TITLE
Create a workflow to run tests automatically for linux and macos

### DIFF
--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -1,0 +1,106 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  - push
+  - pull_request
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  dist:
+    name: Make distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cache ~/perl5
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-dist-locallib
+          path: ~/perl5
+      - name: Perl version
+        run: |
+          perl -v
+      - name: Install cpanm
+        run: |
+          curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+      - name: Install local::lib
+        run: |
+          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+      - name: Make makefile
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          perl Makefile.PL
+      - name: Make distribution
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          make dist
+      - name: Unpack distribution
+        run: mkdir build && tar -xzf *.tar.gz -C build --strip-components=1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./
+  inspect:
+    name: Inspect distribution
+    needs: dist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get dist artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+      - name: Install dependencies
+        run: |
+          sudo apt install tree perl-doc
+      - name: Tree
+        run: tree build
+      - name: License
+        run: cat build/LICENSE
+      - name: Readme
+        run: cat build/README*
+      - name: Changes
+        run: cat build/Changes
+      - name: META.json
+        run: cat build/META.json
+      - name: META.yml
+        run: cat build/META.yml
+      - name: Perldoc
+        run: perldoc -TF  lib/**/*.{pm,pod} 
+  test:
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    needs: dist
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        perl: [ '5.10', '5.16', '5.18', '5.20', '5.22', '5.24',' 5.26',' 5.28', '5.30', '5.32', 'latest' ]
+        experimental: [ false ]
+        include:
+          # SpreadSheet::ParseXLSX needs at least 5.10
+          - os: 'ubuntu-latest'
+            perl: '5.8' 
+            experimental: true
+    steps:
+      - name: Get dist artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - name: Perl version
+        run: perl -V
+      - name: Install dependencies
+        run: cpanm --notest --installdeps ./build
+      - name: Test suite
+        working-directory: ./build/
+        run: prove -lrv t

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Test::Excel.
 
+NEXT
+      - Bumped minimum Perl version to 5.10 to satisfy dependencies.
+
 1.49  Tue Jun 01 16:55:00 2021
       - Fixed bug in ignoring common shell cell range.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ WriteMakefile(
     VERSION_FROM       => 'lib/Test/Excel.pm',
     ABSTRACT_FROM      => 'lib/Test/Excel.pm',
     LICENSE            => 'artistic_2',
-    MIN_PERL_VERSION   => 5.006,
+    MIN_PERL_VERSION   => 5.010,
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => 0,
     },


### PR DESCRIPTION
I have also increased the minimum required Perl version from 5.06 to 5.10 because Spreadsheet::ParseXLSX needs 5.10 to work.

```
! Installing the dependencies failed: Your Perl (5.008009) is not in the range '5.010'
! Bailing out the installation for Spreadsheet-ParseXLSX-0.27.
```

I've not included Windows because I couldn't get it to install XML::Twig as a dependency of Spreadsheet::ParseXLSX, which I think is because if `libexpat`. I couldn't figure out how to make that work on Strawberry Perl.